### PR TITLE
[FIX] remove unsupported and unused file_path import

### DIFF
--- a/muk_web_appsbar/__init__.py
+++ b/muk_web_appsbar/__init__.py
@@ -2,7 +2,7 @@ from . import models
 
 import base64
 
-from odoo.tools import file_open, file_path
+from odoo.tools import file_open
 
 
 def _setup_module(env):

--- a/muk_web_enterprise_theme/__init__.py
+++ b/muk_web_enterprise_theme/__init__.py
@@ -2,7 +2,7 @@ from . import models
 
 import base64
 
-from odoo.tools import file_open, file_path
+from odoo.tools import file_open
 
 
 def _setup_module(env):

--- a/muk_web_theme/__init__.py
+++ b/muk_web_theme/__init__.py
@@ -2,7 +2,7 @@ from . import models
 
 import base64
 
-from odoo.tools import file_open, file_path
+from odoo.tools import file_open
 
 
 def _setup_module(env):


### PR DESCRIPTION
The code you've provided is attempting to use file_open and file_path from odoo.tools, but as indicated by the error, file_path is no longer available in Odoo 17. To fix this issue, I have removed the import of file_path since it is no longer available and is not actually used in your function. The file_open method is sufficient for reading the file in binary mode and encoding it with base64.