### PR TITLE
[ENH] Remove Bottom Border from Main Navbar for Color Consistency

### DIFF
--- a/muk_web_appsbar/__manifest__.py
+++ b/muk_web_appsbar/__manifest__.py
@@ -58,6 +58,7 @@
                 'web/static/src/webclient/webclient.js',
                 'muk_web_appsbar/static/src/webclient/appsbar/appsbar.js',
             ),
+            'muk_web_appsbar/static/src/webclient/navbar/navbar.scss',
             'muk_web_appsbar/static/src/webclient/appsbar/appsbar.xml',
             'muk_web_appsbar/static/src/webclient/appsbar/appsbar.scss',
         ],

--- a/muk_web_appsbar/static/src/webclient/navbar/navbar.scss
+++ b/muk_web_appsbar/static/src/webclient/navbar/navbar.scss
@@ -1,0 +1,3 @@
+.o_main_navbar {
+    border-bottom: none !important;
+}


### PR DESCRIPTION
This pull request addresses a visual inconsistency observed in the main navigation bar of the application. Previously, there was a persistent 1-pixel bottom border whose color could not be adjusted. This rigidity in styling led to a clash with the color scheme of the rest of the navigation bar, especially when custom colors were applied.

To achieve a more cohesive and visually appealing interface, I have removed this bottom border. This change ensures that the navbar's appearance remains smooth and consistent, regardless of the color themes applied. The removal of the border enhances the overall aesthetic of the user interface, aligning it more closely with our design goals of a seamless and customizable user experience.