### PR TITLE
[FIX] Access to environment

### DIFF
--- a/muk_web_appsbar/models/ir_http.py
+++ b/muk_web_appsbar/models/ir_http.py
@@ -1,5 +1,4 @@
 from odoo import models
-from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):
@@ -12,8 +11,8 @@ class IrHttp(models.AbstractModel):
     
     def session_info(self):
         result = super(IrHttp, self).session_info()
-        if request.env.user._is_internal():
-            for company in request.env.user.company_ids.with_context(bin_size=True):
+        if self.env.user._is_internal():
+            for company in self.env.user.company_ids.with_context(bin_size=True):
                 result['user_companies']['allowed_companies'][company.id].update({
                     'has_appsbar_image': bool(company.appbar_image),
                 })

--- a/muk_web_chatter/models/ir_http.py
+++ b/muk_web_chatter/models/ir_http.py
@@ -1,5 +1,4 @@
 from odoo import models
-from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):

--- a/muk_web_dialog/models/ir_http.py
+++ b/muk_web_dialog/models/ir_http.py
@@ -1,5 +1,4 @@
 from odoo import models
-from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):

--- a/muk_web_enterprise_theme/models/ir_http.py
+++ b/muk_web_enterprise_theme/models/ir_http.py
@@ -1,5 +1,4 @@
 from odoo import models
-from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):
@@ -12,8 +11,8 @@ class IrHttp(models.AbstractModel):
     
     def session_info(self):
         result = super(IrHttp, self).session_info()
-        if request.env.user._is_internal():
-            for company in request.env.user.company_ids.with_context(bin_size=True):
+        if self.env.user._is_internal():
+            for company in self.env.user.company_ids.with_context(bin_size=True):
                 result['user_companies']['allowed_companies'][company.id].update({
                     'has_background_image_light': bool(company.background_image_light),
                     'has_background_image_dark': bool(company.background_image_dark),

--- a/muk_web_theme/models/ir_http.py
+++ b/muk_web_theme/models/ir_http.py
@@ -1,5 +1,4 @@
 from odoo import models
-from odoo.http import request
 
 
 class IrHttp(models.AbstractModel):
@@ -12,8 +11,8 @@ class IrHttp(models.AbstractModel):
     
     def session_info(self):
         result = super(IrHttp, self).session_info()
-        if request.env.user._is_internal():
-            for company in request.env.user.company_ids.with_context(bin_size=True):
+        if self.env.user._is_internal():
+            for company in self.env.user.company_ids.with_context(bin_size=True):
                 result['user_companies']['allowed_companies'][company.id].update({
                     'has_background_image': bool(company.background_image),
                 })


### PR DESCRIPTION
When ir.http.session_info() is called from the "/web/session/authenticate" controller the request is anonymous and doesn't have a user. This results in an "AttributeError: 'NoneType' object has no attribute 'xxx'" when calling request.env.user.xxx. This fails (among others) the /web_mobile:MobileRoutesTest.test_authenticate_wrong_credentials unit test. (note: in the unit test error, the Attribute Error is masked by a savepoint related error)