### PR TITLE
[FIX] muk_web_theme cannot be installed with web_responsive

### DIFF
--- a/muk_web_theme/__manifest__.py
+++ b/muk_web_theme/__manifest__.py
@@ -22,6 +22,7 @@
     ],
     'excludes': [
         'web_enterprise',
+        'web_responsive',
     ],
     'data': [
         'templates/web_layout.xml',


### PR DESCRIPTION
The module muk_web_theme is in conflict with [web_responsive](https://github.com/OCA/web/tree/18.0/web_responsive)
This will fixe #34 