### PR TITLE
mcp: surface exception messages in tool call error responses

### DIFF
--- a/muk_mcp/controllers/mcp.py
+++ b/muk_mcp/controllers/mcp.py
@@ -166,7 +166,7 @@ class MCPController(http.Controller):
                 )
             return protocol.make_jsonrpc_error(
                 common.JSONRPC_INTERNAL_ERROR,
-                'Internal server error',
+                f'Internal server error: {exc}',
                 request_id=request_id,
             )
         if method.startswith('notifications/'):
@@ -254,9 +254,17 @@ class MCPController(http.Controller):
                 [protocol.make_text_content(str(exc))],
                 is_error=True,
             )
-        except Exception:
+        except Exception as exc:
+            self._log_request(
+                'tools/call',
+                status='error',
+                tool_name=tool_name,
+                error_message=str(exc),
+            )
             return protocol.make_tool_result(
-                [protocol.make_text_content('Internal server error')],
+                [protocol.make_text_content(
+                    f'Internal server error: {exc}'
+                )],
                 is_error=True,
             )
         if isinstance(result, protocol.ToolResult):


### PR DESCRIPTION
## Summary

The catch-all `except Exception` handlers in `_dispatch_method` and `_handle_tools_call` return a bare `"Internal server error"` string, discarding the actual exception message. This makes debugging MCP tool call failures impossible for consumers — they get a 21-character generic error with no indication of the root cause.

## Changes

- Include `str(exc)` in error responses: `f'Internal server error: {exc}'`
- Always log failed tool calls via `_log_request` (previously skipped for `tools/call` in `_dispatch_method` due to `if not is_tool_call` gate)
- Add `_log_request` call in `_handle_tools_call` catch-all so unexpected errors are recorded in `muk_mcp.log`

## Context

We discovered this while debugging MCP tool calls through a proxy that was double-escaping string-typed `domain` arguments. The Odoo side raised a `Domain() invalid argument type` error, but the MCP controller swallowed it entirely. It took hours of binary-searching through agent session logs to find the problem. With this change, the error message would have been immediately visible:

```
Before: "Internal server error"
After:  "Internal server error: Domain() invalid argument type for domain: '[[\"id\", \"=\", 159]]'"
```

The `/mcp` endpoint is already behind API key authentication, so exposing exception details in the tool result does not create an information leak risk.